### PR TITLE
Bug Fix: Find correct binary on new install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ setup(
     keywords=['aws', 'ssh', 'fuzzy', 'ec2'],
     packages=['aws_fuzzy_finder'],
     package_data={'': [
-        'libs/fzf-0.12.1-linux_386',
-        'libs/fzf-0.12.1-linux_amd64',
-        'libs/fzf-0.12.1-darwin_386',
-        'libs/fzf-0.12.1-darwin_amd64',
+        'libs/fzf-0.17.0-linux_386',
+        'libs/fzf-0.17.0-linux_amd64',
+        'libs/fzf-0.17.0-darwin_386',
+        'libs/fzf-0.17.0-darwin_amd64',
     ]},
     install_requires=[
         'boto3==1.3.1',


### PR DESCRIPTION
On a new install of aws-fuzzy-finder, I got a go stack trace and
aws-fuzzy-finder whould fail to work.

Changing the setup to include the correct version of fzf resolved the
problem.