### PR TITLE
fix/cache: use profile specified from AWS_PROFILE instead of the default one

### DIFF
--- a/aws_fuzzy_finder/settings.py
+++ b/aws_fuzzy_finder/settings.py
@@ -16,7 +16,7 @@ CACHE_EXPIRY_TIME = int(os.getenv('AWS_FUZZ_CACHE_EXPIRY', 3600))
 CACHE_ENABLED = os.getenv('AWS_FUZZ_USE_CACHE', False)
 AWS_DEFAULT_PROFILE=os.getenv('AWS_DEFAULT_PROFILE', 'default')
 CACHE_DIR = '{}/{}'.format(expanduser("~"), '.aws_fuzzy_finder_cache')
-CACHE_PATH = '{}/{}'.format(CACHE_DIR, AWS_DEFAULT_PROFILE)
+CACHE_PATH = '{}/{}'.format(CACHE_DIR, os.getenv('AWS_PROFILE', AWS_DEFAULT_PROFILE))
 
 fzf_base = 'fzf-0.17.0'
 is_64_bit = sys.maxsize > 2**32


### PR DESCRIPTION
awscli uses the AWS_PROFILE to determine which profile to use.
This is not taken into account here so we show the cache from the wrong profile, this PR changes this behavior to create independent caches based on the profile name.